### PR TITLE
fix: Use dynamic versioning for scikit-build-core with subdirectory

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,8 +2,8 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    # branches: ["main"]
-    # tags: [v*]
+    branches: ["main"]
+    tags: [v*]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,8 +2,8 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    branches: ["main"]
-    tags: [v*]
+    # branches: ["main"]
+    # tags: [v*]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/examples/compiled_packaging/pyproject.toml
+++ b/examples/compiled_packaging/pyproject.toml
@@ -8,8 +8,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "rosen-cpp"
-# dynamic = ["version"]
-version = "0.0.1"
+dynamic = ["version"]
 description = "Example package for demonstration"
 readme = "README.md"
 license = { text = "MIT" }  # SPDX short identifier
@@ -42,13 +41,14 @@ Homepage = "https://github.com/matthewfeickert-talks/talk-odsl-forum-seminar-202
 Documentation = "https://github.com/matthewfeickert-talks/talk-odsl-forum-seminar-2023"
 "Bug Tracker" = "https://github.com/matthewfeickert-talks/talk-odsl-forum-seminar-2023/issues"
 
-[tool.hatch.version]
-source = "vcs"
+[tool.scikit-build]
+minimum-version = "0.4"
+build-dir = "build/{wheel_tag}"
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+sdist.include = ["src/rosen_cpp/_version.py"]
 
-[tool.hatch.version.raw-options]
+[tool.setuptools_scm]
+write_to = "src/rosen_cpp/_version.py"
 local_scheme = "no-local-version"
 # Need to give root as we aren't at the same level as the git repo
 root = "../.."
-
-[tool.hatch.build.hooks.vcs]
-version-file = "src/rosen_cpp/_version.py"

--- a/examples/compiled_packaging/pyproject.toml
+++ b/examples/compiled_packaging/pyproject.toml
@@ -48,7 +48,8 @@ metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 sdist.include = ["src/rosen_cpp/_version.py"]
 
 [tool.setuptools_scm]
-write_to = "src/rosen_cpp/_version.py"
 local_scheme = "no-local-version"
 # Need to give root as we aren't at the same level as the git repo
 root = "../.."
+# Need to provide path relative to root
+# write_to = "examples/compiled_packaging/src/rosen_cpp/_version.py"

--- a/examples/compiled_packaging/pyproject.toml
+++ b/examples/compiled_packaging/pyproject.toml
@@ -52,4 +52,4 @@ local_scheme = "no-local-version"
 # Need to give root as we aren't at the same level as the git repo
 root = "../.."
 # Need to provide path relative to root
-# write_to = "examples/compiled_packaging/src/rosen_cpp/_version.py"
+write_to = "examples/compiled_packaging/src/rosen_cpp/_version.py"

--- a/examples/compiled_packaging/pyproject.toml
+++ b/examples/compiled_packaging/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-  "scikit-build-core",
-  "pybind11"
+  "scikit-build-core>=0.5.0",
+  "pybind11>=2.10.0",
   ]
 build-backend = "scikit_build_core.build"
 
@@ -42,14 +42,16 @@ Documentation = "https://github.com/matthewfeickert-talks/talk-odsl-forum-semina
 "Bug Tracker" = "https://github.com/matthewfeickert-talks/talk-odsl-forum-seminar-2023/issues"
 
 [tool.scikit-build]
-minimum-version = "0.4"
-build-dir = "build/{wheel_tag}"
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-sdist.include = ["src/rosen_cpp/_version.py"]
 
 [tool.setuptools_scm]
+# Ignore the commit hash in version
 local_scheme = "no-local-version"
 # Need to give root as we aren't at the same level as the git repo
 root = "../.."
-# Need to provide path relative to root
-write_to = "examples/compiled_packaging/src/rosen_cpp/_version.py"
+
+[[tool.scikit-build.generate]]
+path = "rosen_cpp/_version.py"
+template = '''
+version = "${version}"
+'''

--- a/examples/compiled_packaging/src/rosen_cpp/__init__.py
+++ b/examples/compiled_packaging/src/rosen_cpp/__init__.py
@@ -1,0 +1,7 @@
+from rosen_cpp._version import version as __version__
+
+__all__ = ["__version__"]
+
+
+def __dir__():
+    return __all__


### PR DESCRIPTION
c.f. https://github.com/scikit-build/scikit-build-core/issues/495

```
* Use scikit-build.generate to write package version information along with
  tool.setuptools_scm options to provide path to root directory of Git repo.
   - c.f.https://github.com/scikit-build/scikit-build-core/issues/495
* Add import of version information as __version__ to allow rosen_cpp.__version__ API.
```